### PR TITLE
Fix audience

### DIFF
--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -154,11 +154,13 @@ export default class auth {
           return;
         }
         if (authResult.accessToken && authResult.idToken) {
-          this.tokenRefreshed(authResult);
-          resolve({
-            idToken: authResult.idToken,
-            sub: authResult.idTokenPayload.sub,
-          });
+          this.tokenRefreshed(authResult)
+            .then(() => {
+              resolve({
+                idToken: authResult.idToken,
+                sub: authResult.idTokenPayload.sub,
+              });
+            });
         } else {
           reject({ error: 'no_token_available', errorDescription: 'Failed to get valid token.', authResultError: authResult.error });
         }

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -89,8 +89,7 @@ export default class auth {
     }
 
     // The 1000ms here is guarantee that the websocket is finished loading
-    return new Promise(resolve => setTimeout(() => resolve(), 1000))
-      .then(() => this.renewAuth())
+    this.renewAuth()
       .catch((e) => {
         this.log('Renew authorization did not succeed, falling back to login widget', e);
         return new Promise((resolve, reject) => {

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -89,7 +89,7 @@ export default class auth {
     }
 
     // The 1000ms here is guarantee that the websocket is finished loading
-    this.renewAuth()
+    return this.renewAuth()
       .catch((e) => {
         this.log('Renew authorization did not succeed, falling back to login widget', e);
         return new Promise((resolve, reject) => {

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -121,7 +121,6 @@ describe('auth.js', () => {
 
   describe('ensureLoggedIn()', () => {
     it('follows correct procedure', () => {
-      const clock = sandbox.useFakeTimers();
       const auth = new Auth();
       const mock = sandbox.mock(auth);
       const loginInfo = { idToken: 'unit-test-id-token', sub: 'unit-test-sub' };
@@ -131,7 +130,6 @@ describe('auth.js', () => {
       mock.expects('profileRefreshed').withExactArgs(profile).once().resolves();
 
       const promise = auth.ensureLoggedIn();
-      clock.tick(1000);
 
       return promise
         .then(() => {


### PR DESCRIPTION
The auth0 lock doesn't return the audience with the token unless the `oidcConformance` flag is enabled with the application. In order to do so, Cross-Origin Authentication must also be enabled with a single callback URL.

Webauth however isn't restricted by the auth0 lock. The solution taken here is to call webauth directly after a successful auth0 lock login.