### PR TITLE
Add automatic token refresh based on token expiry time

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ import Auth from 'auth0-sso-login';
 // create an instance of Auth
 let config = { /* ... */ };
 let auth = new Auth(config);
+// Optionally try to silently login the current user
+auth.ensureLoggedIn({ enableLockWidget: false })
+.catch(e => console.log('SSO session was invalid, user did not log in', e));
 
-// Verifies that the user is logged in
-// returns a promise, when succeeded, the user is logged in
-// and a valid JWT was provided.
+// Logs the user in returns a promise, when succeeded, the user is logged in
+// and a valid JWT was provided (via tokenRefreshed hook).
 // Schedules automatic background renewal of JWT based on its expiry time.
 // (it will be refresh in the 2/3 of the current token lifetime)
 auth.ensureLoggedIn()
@@ -37,7 +39,7 @@ auth.ensureLoggedIn()
     // be logged in automatically through Auth0's SSO feature, or
     // the Auth0Lock will handle the login, and only succeed after
     // the user successfully logged in.
-};
+});
 ```
 
 Several configuration options and hooks are provided to interact with the library.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ let config = {
       // once a new token was retrieved from auth0
       // a typical use case is to store the token for calling other services
     },
-    // called when there's a problem with the current user, for example an invalid token
+    // called before logout or when there's a problem with the current user, for example an invalid token
     // this gives implementors the option to remove the current user's details from the store if saved
     removeLogin() {
       // typical use case it to provide the same method as for logout

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ import Auth from 'auth0-sso-login';
 // create an instance of Auth
 let config = { /* ... */ };
 let auth = new Auth(config);
-// Optionally try to silently login the current user
-auth.ensureLoggedIn({ enableLockWidget: false })
-.catch(e => console.log('SSO session was invalid, user did not log in', e));
-
-// Logs the user in returns a promise, when succeeded, the user is logged in
+let defaultConfiguration = {
+  enableLockWidget: true,  // if Auth0's SSO fails, use Auth0Lock
+  forceTokenRefresh: false // force refresh even if there is a valid token available
+};
+// Logs the user in and returns a promise, when succeeded, the user is logged in
 // and a valid JWT was provided (via tokenRefreshed hook).
 // Schedules automatic background renewal of JWT based on its expiry time.
 // (it will be refresh in the 2/3 of the current token lifetime)
-auth.ensureLoggedIn()
+auth.ensureLoggedIn(defaultConfiguration)
 .then(() => console.log('user is logged in'))
 .catch(error => {
     console.error('an unexpected error occurred while logging in');
@@ -41,6 +41,14 @@ auth.ensureLoggedIn()
     // the user successfully logged in.
 });
 ```
+
+After the login process, the token is retrieved via `tokenRefreshed` hook, described in the
+configuration options bellow. The library also exposes its latest authorization result, which may or
+may not be set (depends on the success/failure of login process). This method can be used as
+a token provider for HTTP clients.
+```javascript
+let authResult = auth.getLatestAuthResult();
+``` 
 
 Several configuration options and hooks are provided to interact with the library.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auth0 SSO Login
 
-[![Build Status](https://travis-ci.org/Cimpress-MCP/auth0-sso-login.js.svg?branch=master)](https://travis-ci.org/Cimpress-MCP/auth0-sso-login.js) 
+[![Build Status](https://travis-ci.org/Cimpress-MCP/auth0-sso-login.js.svg?branch=master)](https://travis-ci.org/Cimpress-MCP/auth0-sso-login.js)
 [![npm version](https://badge.fury.io/js/auth0-sso-login.svg)](https://www.npmjs.com/package/auth0-sso-login)
 
 The Auth0 SSO Login provides an easy to use library for single-sign on web pages that are leveraging [Auth0](https://auth0.com/) and related [Auth0 Lock](https://auth0.com/lock).
@@ -23,13 +23,11 @@ import Auth from 'auth0-sso-login';
 let config = { /* ... */ };
 let auth = new Auth(config);
 
-// optionally call "stay logged in" which is a background process
-// that ensures hourly that the user stay logged in
-auth.stayLoggedIn();
-
-// verifies that the user is logged in
+// Verifies that the user is logged in
 // returns a promise, when succeeded, the user is logged in
 // and a valid JWT was provided.
+// Schedules automatic background renewal of JWT based on its expiry time.
+// (it will be refresh in the 2/3 of the current token lifetime)
 auth.ensureLoggedIn()
 .then(() => console.log('user is logged in'))
 .catch(error => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-login",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -132,6 +132,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -983,6 +989,20 @@
       "integrity": "sha1-kxohp72FAWMAMo0h8SbYS3NDfTU=",
       "dev": true
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
+      }
+    },
     "chain-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
@@ -1019,6 +1039,12 @@
         }
       }
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1028,6 +1054,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1198,6 +1225,15 @@
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.3"
       }
     },
     "deep-is": {
@@ -1647,6 +1683,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
@@ -2407,6 +2449,13 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
+    },
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
@@ -2640,6 +2689,12 @@
       "requires": {
         "pify": "2.3.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -3152,6 +3207,12 @@
         "text-encoding": "0.6.4",
         "type-detect": "4.0.3"
       }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-sso-login",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A Library to simplify the auth0 sso login process",
   "main": "lib/auth0-sso-login.js",
   "scripts": {
@@ -32,10 +32,12 @@
     "babel-preset-env": "^1.6.0",
     "ci-build-tools": "1.0.9",
     "commander": "2.11.0",
+    "chai": "^4.1.2",
     "eslint": "4.5.0",
     "eslint-config-airbnb-base": "11.3.1",
     "eslint-plugin-import": "2.7.0",
     "mocha": "^3.5.0",
-    "sinon": "^3.2.1"
+    "sinon": "^3.2.1",
+    "sinon-chai": "^2.14.0"
   }
 }

--- a/src/auth0-lock-factory.js
+++ b/src/auth0-lock-factory.js
@@ -1,0 +1,8 @@
+import Auth0Lock from 'auth0-lock';
+
+// static class making unit testing possible
+export default class auth0LockFactory {
+  static createAuth0Lock(clientId, domain, options) {
+    return new Auth0Lock(clientId, domain, options);
+  }
+}

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -143,8 +143,10 @@ export default class auth {
   }
 
   /**
-   * @description Try to login, first using an existing SSO session. If that fails and auth0 lock
-   * widget is not explicitly disabled, show auth0 lock to the user.
+   * @description Ensure user is logged in:
+   * 1. Check if there is an existing, valid token.
+   * 2. Try logging in using an existing SSO session.
+   * 3. If auth0 lock widget is not explicitly disabled, try logging in using auth0 lock.
    *
    * @param {Object}     configuration object
    * @param {Boolean}    configuration.enableLockWidget whether auth0 lock should open when SSO

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -98,14 +98,17 @@ export default class auth {
   }
 
   /**
-   * @description Calls a hook to log out the user, and then interacts with Auth0 to actually
-   * log the user out.
+   * @description Calls a hook to removeLogin and logout the user, and then interacts with Auth0 to
+   * actually log the user out.
    */
   logout() {
     this.tokenExpiryManager.cancelTokenRefresh();
     this.authResult = null;
 
     if (this.config) {
+      if (this.config.hooks && this.config.hooks.removeLogin) {
+        this.config.hooks.removeLogin();
+      }
       if (this.config.hooks && this.config.hooks.logout) {
         this.config.hooks.logout();
       }

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -1,14 +1,7 @@
-import Auth0Lock from 'auth0-lock';
 import auth0 from 'auth0-js';
 import windowInteraction from './window-interaction';
+import auth0LockFactory from './auth0-lock-factory';
 import TokenExpiryManager from './token-expiry-manager';
-
-// static class making unit testing possible
-export class auth0LockFactory {
-  static createAuth0Lock(clientId, domain, options) {
-    return new Auth0Lock(clientId, domain, options);
-  }
-}
 
 // authentication class
 export default class auth {

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -31,8 +31,10 @@ export class localStorageInteraction {
   }
 }
 
+export const tokenExpiresAtKey = 'cimpress.auth0.tokenExpiresAt';
+
 const scheduleRenewal = (tokenRefreshHandle, renewFunction) => {
-  const tokenExpiresAtJson = localStorageInteraction.getItem('tokenExpiresAt');
+  const tokenExpiresAtJson = localStorageInteraction.getItem(tokenExpiresAtKey);
   if (!tokenExpiresAtJson) {
     return null;
   }
@@ -89,7 +91,7 @@ export default class auth {
   // calls a hook once the token got refreshed
   tokenRefreshed(authResult) {
     const tokenExpiresAt = JSON.stringify((authResult.expiresIn * 1000) + Date.now());
-    localStorageInteraction.setItem('tokenExpiresAt', tokenExpiresAt);
+    localStorageInteraction.setItem(tokenExpiresAtKey, tokenExpiresAt);
     this.tokenRefreshHandle = scheduleRenewal(this.tokenRefreshHandle, () => this.ensureLoggedIn());
 
     if (this.config.hooks && this.config.hooks.tokenRefreshed) {
@@ -102,7 +104,7 @@ export default class auth {
   removeLogin() {
     if (this.tokenRefreshHandle) {
       windowInteraction.clearTimeout(this.tokenRefreshHandle);
-      localStorageInteraction.removeItem('tokenExpiresAt');
+      localStorageInteraction.removeItem(tokenExpiresAtKey);
     }
 
     if (this.config.hooks && this.config.hooks.removeLogin) {
@@ -115,7 +117,7 @@ export default class auth {
   logout() {
     if (this.tokenRefreshHandle) {
       windowInteraction.clearTimeout(this.tokenRefreshHandle);
-      localStorageInteraction.removeItem('tokenExpiresAt');
+      localStorageInteraction.removeItem(tokenExpiresAtKey);
     }
 
     if (this.config) {

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -3,6 +3,13 @@ import auth0 from 'auth0-js';
 import windowInteraction from './window-interaction';
 import TokenExpiryManager from './token-expiry-manager';
 
+// static class making unit testing possible
+export class auth0LockFactory {
+  static createAuth0Lock(clientId, domain, options) {
+    return new Auth0Lock(clientId, domain, options);
+  }
+}
+
 // authentication class
 export default class auth {
   /**
@@ -159,7 +166,8 @@ export default class auth {
         }
         this.log('Renew authorization did not succeed, falling back to login widget', e);
         return new Promise((resolve, reject) => {
-          const lock = new Auth0Lock(this.config.clientId, this.config.domain, options);
+          const lock = auth0LockFactory.createAuth0Lock(this.config.clientId, this.config.domain,
+            options);
           lock.on('authenticated', (authResult) => {
             this.renewAuth()
               .then(() => {

--- a/src/token-expiry-manager.js
+++ b/src/token-expiry-manager.js
@@ -7,23 +7,20 @@ export default class tokenExpiryManager {
   }
 
   getRemainingMillisToTokenExpiry() {
-    if (!this.tokenExpiresAt) {
-      return 0;
-    }
-
-    return Math.floor((this.tokenExpiresAt - Date.now()) / 3) * 2;
+    return this.tokenExpiresAt ? this.tokenExpiresAt - Date.now() : 0;
   }
 
   scheduleTokenRefresh(authResult, refreshFunction) {
-    this.tokenExpiresAt = (authResult.expiresIn * 1000) + Date.now();
+    const expiresInMs = authResult.expiresIn * 1000;
+    const remainingMs = (expiresInMs / 3) * 2;
+
+    this.tokenExpiresAt = remainingMs + Date.now();
 
     if (this.tokenRefreshHandle) {
       windowInteraction.clearTimeout(this.tokenRefreshHandle);
     }
 
-    this.tokenRefreshHandle = windowInteraction.setTimeout(
-      refreshFunction,
-      this.getRemainingMillisToTokenExpiry());
+    this.tokenRefreshHandle = windowInteraction.setTimeout(refreshFunction, remainingMs);
   }
 
   cancelTokenRefresh() {
@@ -31,6 +28,7 @@ export default class tokenExpiryManager {
 
     if (this.tokenRefreshHandle) {
       windowInteraction.clearTimeout(this.tokenRefreshHandle);
+      this.tokenRefreshHandle = null;
     }
   }
 }

--- a/src/token-expiry-manager.js
+++ b/src/token-expiry-manager.js
@@ -1,6 +1,6 @@
 import windowInteraction from './window-interaction';
 
-export default class TokenExpiryManager {
+export default class tokenExpiryManager {
   constructor() {
     this.tokenExpiresAt = null;
     this.tokenRefreshHandle = null;

--- a/src/token-expiry-manager.js
+++ b/src/token-expiry-manager.js
@@ -1,0 +1,36 @@
+import windowInteraction from './window-interaction';
+
+export default class TokenExpiryManager {
+  constructor() {
+    this.tokenExpiresAt = null;
+    this.tokenRefreshHandle = null;
+  }
+
+  getRemainingMillisToTokenExpiry() {
+    if (!this.tokenExpiresAt) {
+      return 0;
+    }
+
+    return Math.floor((this.tokenExpiresAt - Date.now()) / 3) * 2;
+  }
+
+  scheduleTokenRefresh(authResult, refreshFunction) {
+    this.tokenExpiresAt = (authResult.expiresIn * 1000) + Date.now();
+
+    if (this.tokenRefreshHandle) {
+      windowInteraction.clearTimeout(this.tokenRefreshHandle);
+    }
+
+    this.tokenRefreshHandle = windowInteraction.setTimeout(
+      refreshFunction,
+      this.getRemainingMillisToTokenExpiry());
+  }
+
+  cancelTokenRefresh() {
+    this.tokenExpiresAt = null;
+
+    if (this.tokenRefreshHandle) {
+      windowInteraction.clearTimeout(this.tokenRefreshHandle);
+    }
+  }
+}

--- a/src/window-interaction.js
+++ b/src/window-interaction.js
@@ -1,0 +1,14 @@
+// static window interaction, mostly wrapped for enabling easier mocking through unit tests
+export default class windowInteraction {
+  static updateWindow(url) {
+    window.location = url;
+  }
+
+  static setTimeout(func, delay) {
+    return window.setTimeout(func, delay);
+  }
+
+  static clearTimeout(timeoutId) {
+    window.clearTimeout(timeoutId);
+  }
+}

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 });
 afterEach(() => sandbox.restore());
 
-describe('auth.js', () => {
+describe('auth0-sso-login.js', () => {
   describe('when notifying hooks', () => {
     describe('for logging', () => {
       it('logs to provided log function', () => {

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -95,22 +95,22 @@ describe('auth0-sso-login.js', () => {
 
     describe('for logout', () => {
       it('invokes hook', () => {
-        const hook = { logout() { } };
-        const mock = sandbox.mock(hook);
-        mock.expects('logout').once().resolves();
+        const logoutHook = sandbox.stub();
+        const removeLoginHook = sandbox.stub();
         const tokenExpiryManager = { cancelTokenRefresh() {} };
         const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
         tokenExpiryManagerMock.expects('cancelTokenRefresh').once();
         const windowInteractionMock = sandbox.mock(windowInteraction);
         windowInteractionMock.expects('updateWindow').once();
 
-        const auth = new Auth({ hooks: { logout: hook.logout } });
+        const auth = new Auth({ hooks: { logout: logoutHook, removeLogin: removeLoginHook } });
         auth.tokenExpiryManager = tokenExpiryManager;
         auth.authResult = { testResult: 'unit-test-result' };
 
         auth.logout();
         expect(auth.getLatestAuthResult()).to.be.null;
-        mock.verify();
+        expect(logoutHook.calledOnce).to.be.true;
+        expect(removeLoginHook.calledOnce).to.be.true;
         windowInteractionMock.verify();
         tokenExpiryManagerMock.verify();
       });

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -3,7 +3,7 @@ import { describe, it, beforeEach, afterEach } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chai from 'chai';
-import Auth, { windowInteraction, localStorageInteraction } from '../src/auth0-sso-login';
+import Auth, { windowInteraction, localStorageInteraction, tokenExpiresAtKey } from '../src/auth0-sso-login';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -34,7 +34,7 @@ describe('auth.js', () => {
       // unwrap the default method stub
       localStorageInteraction.getItem.restore();
       const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-      localStorageInteractionMock.expects('getItem').withExactArgs('tokenExpiresAt').returns(expectedExpiresAt);
+      localStorageInteractionMock.expects('getItem').withExactArgs(tokenExpiresAtKey).returns(expectedExpiresAt);
 
       const windowInteractionMock = sandbox.mock(windowInteraction);
       windowInteractionMock.expects('setTimeout').withExactArgs(sinon.match.func, expectedRefreshDelay).returns(testHandle);
@@ -128,8 +128,8 @@ describe('auth.js', () => {
         // unwrap the default method stub
         localStorageInteraction.getItem.restore();
         const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('setItem').withExactArgs('tokenExpiresAt', expectedExpiresAt).once();
-        localStorageInteractionMock.expects('getItem').withExactArgs('tokenExpiresAt').returns(undefined);
+        localStorageInteractionMock.expects('setItem').withExactArgs(tokenExpiresAtKey, expectedExpiresAt).once();
+        localStorageInteractionMock.expects('getItem').withExactArgs(tokenExpiresAtKey).returns(undefined);
 
         auth.tokenRefreshed(authResult);
         expect(auth.tokenRefreshHandle).to.equal(null);
@@ -159,8 +159,8 @@ describe('auth.js', () => {
         // unwrap the default method stub
         localStorageInteraction.getItem.restore();
         const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('setItem').withExactArgs('tokenExpiresAt', expectedExpiresAt).once();
-        localStorageInteractionMock.expects('getItem').withExactArgs('tokenExpiresAt').returns(expectedExpiresAt);
+        localStorageInteractionMock.expects('setItem').withExactArgs(tokenExpiresAtKey, expectedExpiresAt).once();
+        localStorageInteractionMock.expects('getItem').withExactArgs(tokenExpiresAtKey).returns(expectedExpiresAt);
 
         auth.tokenRefreshHandle = previousHandle;
         auth.tokenRefreshed(authResult);
@@ -200,7 +200,7 @@ describe('auth.js', () => {
         windowInteractionMock.expects('updateWindow').once();
         windowInteractionMock.expects('clearTimeout').withExactArgs('unit-test-handle').once();
         const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('removeItem').withExactArgs('tokenExpiresAt').once();
+        localStorageInteractionMock.expects('removeItem').withExactArgs(tokenExpiresAtKey).once();
         auth.logout();
         windowInteractionMock.verify();
         localStorageInteractionMock.verify();
@@ -228,7 +228,7 @@ describe('auth.js', () => {
         const windowInteractionMock = sandbox.mock(windowInteraction);
         windowInteractionMock.expects('clearTimeout').withExactArgs('unit-test-handle').once();
         const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('removeItem').withExactArgs('tokenExpiresAt').once();
+        localStorageInteractionMock.expects('removeItem').withExactArgs(tokenExpiresAtKey).once();
         auth.removeLogin();
         windowInteractionMock.verify();
         localStorageInteractionMock.verify();

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -3,7 +3,8 @@ import { describe, it, beforeEach, afterEach } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chai from 'chai';
-import Auth, { windowInteraction, localStorageInteraction, tokenExpiresAtKey } from '../src/auth0-sso-login';
+import Auth, { Auth0LockFactory } from '../src/auth0-sso-login';
+import windowInteraction from '../src/window-interaction';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -11,42 +12,10 @@ chai.use(sinonChai);
 let sandbox;
 beforeEach(() => {
   sandbox = sinon.sandbox.create();
-  sandbox.stub(localStorageInteraction, 'getItem').returns(undefined);
 });
 afterEach(() => sandbox.restore());
 
 describe('auth.js', () => {
-  describe('constructor', () => {
-    it('does not schedule token renewal if expiry time is not available', () => {
-      const auth = new Auth();
-      expect(auth.tokenRefreshHandle).to.be.null;
-    });
-
-    it('does schedule token renewal if expiry time is present', () => {
-      const testHandle = 'unit-test-handle';
-      const dateNow = 20000;
-      const expectedExpiresAt = JSON.stringify(35000);
-      // refresh in 2/3 of token lifetime
-      const expectedRefreshDelay = 10000;
-
-      const dateMock = sandbox.mock(Date);
-      dateMock.expects('now').once().returns(dateNow);
-      // unwrap the default method stub
-      localStorageInteraction.getItem.restore();
-      const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-      localStorageInteractionMock.expects('getItem').withExactArgs(tokenExpiresAtKey).returns(expectedExpiresAt);
-
-      const windowInteractionMock = sandbox.mock(windowInteraction);
-      windowInteractionMock.expects('setTimeout').withExactArgs(sinon.match.func, expectedRefreshDelay).returns(testHandle);
-
-      const auth = new Auth();
-      expect(auth.tokenRefreshHandle).to.equal(testHandle);
-      localStorageInteractionMock.verify();
-      windowInteractionMock.verify();
-      dateMock.verify();
-    });
-  });
-
   describe('when notifying hooks', () => {
     describe('for logging', () => {
       it('logs to provided log function', () => {
@@ -97,77 +66,29 @@ describe('auth.js', () => {
         const mock = sandbox.mock(hook);
         const authResult = { unitTestAuthResult: 'unit-test-auth-result' };
         mock.expects('tokenRefreshed').withExactArgs(authResult).once().resolves();
-        sandbox.stub(localStorageInteraction, 'setItem');
+        const tokenExpiryManager = { scheduleTokenRefresh() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        tokenExpiryManagerMock.expects('scheduleTokenRefresh').withExactArgs(authResult, sinon.match.func);
         const auth = new Auth({ hooks: { tokenRefreshed: hook.tokenRefreshed } });
+        auth.tokenExpiryManager = tokenExpiryManager;
         return auth.tokenRefreshed(authResult)
           .then(() => {
             mock.verify();
+            tokenExpiryManagerMock.verify();
           });
       });
 
       it('does not fail when no hook provided', () => {
         const authResult = { unitTestAuthResult: 'unit-test-auth-result' };
-        sandbox.stub(localStorageInteraction, 'setItem');
+        const tokenExpiryManager = { scheduleTokenRefresh() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        tokenExpiryManagerMock.expects('scheduleTokenRefresh').withExactArgs(authResult, sinon.match.func);
         const auth = new Auth();
+        auth.tokenExpiryManager = tokenExpiryManager;
 
         // return promise, to ensure it didn't fail
-        return auth.tokenRefreshed(authResult);
-      });
-
-      it('stores token expiry time', () => {
-        const expiresIn = 15000;
-        const dateNow = 20000;
-        const expectedExpiresAt = JSON.stringify(35000);
-
-        const authResult = { unitTestAuthResult: 'unit-test-auth-result', expiresIn: expiresIn / 1000 };
-        const auth = new Auth();
-
-        const dateMock = sandbox.mock(Date);
-        dateMock.expects('now').once().returns(dateNow);
-
-        // unwrap the default method stub
-        localStorageInteraction.getItem.restore();
-        const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('setItem').withExactArgs(tokenExpiresAtKey, expectedExpiresAt).once();
-        localStorageInteractionMock.expects('getItem').withExactArgs(tokenExpiresAtKey).returns(undefined);
-
-        auth.tokenRefreshed(authResult);
-        expect(auth.tokenRefreshHandle).to.equal(null);
-        localStorageInteractionMock.verify();
-        dateMock.verify();
-      });
-
-      it('removes scheduled token refresh and schedules new refresh time', () => {
-        const expiresIn = 15000;
-        const dateNow = 20000;
-        const expectedExpiresAt = JSON.stringify(35000);
-        // refresh in 2/3 of token lifetime
-        const expectedRefreshDelay = 10000;
-
-        const authResult = { unitTestAuthResult: 'unit-test-auth-result', expiresIn: expiresIn / 1000 };
-        const auth = new Auth();
-
-        const dateMock = sandbox.mock(Date);
-        dateMock.expects('now').twice().returns(dateNow);
-
-        const previousHandle = 'previous-handle';
-        const newHandle = 'new-handle';
-        const windowInteractionMock = sandbox.mock(windowInteraction);
-        windowInteractionMock.expects('clearTimeout').withExactArgs(previousHandle);
-        windowInteractionMock.expects('setTimeout').withExactArgs(sinon.match.func, expectedRefreshDelay).once().returns(newHandle);
-
-        // unwrap the default method stub
-        localStorageInteraction.getItem.restore();
-        const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('setItem').withExactArgs(tokenExpiresAtKey, expectedExpiresAt).once();
-        localStorageInteractionMock.expects('getItem').withExactArgs(tokenExpiresAtKey).returns(expectedExpiresAt);
-
-        auth.tokenRefreshHandle = previousHandle;
-        auth.tokenRefreshed(authResult);
-        expect(auth.tokenRefreshHandle).to.equal(newHandle);
-        localStorageInteractionMock.verify();
-        dateMock.verify();
-        windowInteractionMock.verify();
+        return auth.tokenRefreshed(authResult)
+          .then(() => tokenExpiryManagerMock.verify());
       });
     });
 
@@ -176,34 +97,38 @@ describe('auth.js', () => {
         const hook = { logout() { } };
         const mock = sandbox.mock(hook);
         mock.expects('logout').once().resolves();
-        const auth = new Auth({ hooks: { logout: hook.logout } });
+        const tokenExpiryManager = { cancelTokenRefresh() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        tokenExpiryManagerMock.expects('cancelTokenRefresh').once();
         const windowInteractionMock = sandbox.mock(windowInteraction);
         windowInteractionMock.expects('updateWindow').once();
+
+        const auth = new Auth({ hooks: { logout: hook.logout } });
+        auth.tokenExpiryManager = tokenExpiryManager;
+        auth.authResult = { testResult: 'unit-test-result' };
+
         auth.logout();
+        expect(auth.getLatestAuthResult()).to.be.null;
         mock.verify();
         windowInteractionMock.verify();
+        tokenExpiryManagerMock.verify();
       });
 
       it('does not fail when no hook provided', () => {
-        const auth = new Auth();
-        // const authMock = sandbox.mock(auth);
+        const tokenExpiryManager = { cancelTokenRefresh() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        tokenExpiryManagerMock.expects('cancelTokenRefresh').once();
         const windowInteractionMock = sandbox.mock(windowInteraction);
         windowInteractionMock.expects('updateWindow').once();
-        auth.logout();
-        windowInteractionMock.verify();
-      });
 
-      it('clears stored token expiry time and stops automatic refresh', () => {
         const auth = new Auth();
-        auth.tokenRefreshHandle = 'unit-test-handle';
-        const windowInteractionMock = sandbox.mock(windowInteraction);
-        windowInteractionMock.expects('updateWindow').once();
-        windowInteractionMock.expects('clearTimeout').withExactArgs('unit-test-handle').once();
-        const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('removeItem').withExactArgs(tokenExpiresAtKey).once();
+        auth.tokenExpiryManager = tokenExpiryManager;
+        auth.authResult = { testResult: 'unit-test-result' };
+
         auth.logout();
+        expect(auth.getLatestAuthResult()).to.be.null;
         windowInteractionMock.verify();
-        localStorageInteractionMock.verify();
+        tokenExpiryManagerMock.verify();
       });
     });
 
@@ -212,46 +137,125 @@ describe('auth.js', () => {
         const hook = { removeLogin() { } };
         const mock = sandbox.mock(hook);
         mock.expects('removeLogin').once().resolves();
+        const tokenExpiryManager = { cancelTokenRefresh() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        tokenExpiryManagerMock.expects('cancelTokenRefresh').once();
+
         const auth = new Auth({ hooks: { removeLogin: hook.removeLogin } });
+        auth.tokenExpiryManager = tokenExpiryManager;
+        auth.authResult = { testResult: 'unit-test-result' };
+
         auth.removeLogin();
+        expect(auth.getLatestAuthResult()).to.be.null;
+        tokenExpiryManagerMock.verify();
         mock.verify();
       });
 
       it('does not fail when no hook provided', () => {
+        const tokenExpiryManager = { cancelTokenRefresh() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        tokenExpiryManagerMock.expects('cancelTokenRefresh').once();
         const auth = new Auth();
-        auth.removeLogin();
-      });
+        auth.tokenExpiryManager = tokenExpiryManager;
+        auth.authResult = { testResult: 'unit-test-result' };
 
-      it('clears stored token expiry time and stops automatic refresh', () => {
-        const auth = new Auth();
-        auth.tokenRefreshHandle = 'unit-test-handle';
-        const windowInteractionMock = sandbox.mock(windowInteraction);
-        windowInteractionMock.expects('clearTimeout').withExactArgs('unit-test-handle').once();
-        const localStorageInteractionMock = sandbox.mock(localStorageInteraction);
-        localStorageInteractionMock.expects('removeItem').withExactArgs(tokenExpiresAtKey).once();
         auth.removeLogin();
-        windowInteractionMock.verify();
-        localStorageInteractionMock.verify();
+        expect(auth.getLatestAuthResult()).to.be.null;
+        tokenExpiryManagerMock.verify();
       });
     });
   });
 
   describe('ensureLoggedIn()', () => {
-    it('follows correct procedure', () => {
-      const auth = new Auth();
-      const mock = sandbox.mock(auth);
-      const loginInfo = { idToken: 'unit-test-id-token', sub: 'unit-test-sub' };
-      const profile = { sub: loginInfo.sub };
-      mock.expects('renewAuth').once().resolves(loginInfo);
-      mock.expects('getDetailedProfile').withExactArgs(loginInfo.idToken, loginInfo.sub).once().resolves(profile);
-      mock.expects('profileRefreshed').withExactArgs(profile).once().resolves();
+    const catchableError = 'catchable-unit-test-error';
+    const testLoginInfo = { idToken: 'unit-test-id-token', sub: 'unit-test-sub' };
+    const testProfile = { sub: testLoginInfo.sub };
+    const testAuthResult = { idToken: testLoginInfo.idToken, accessToken: 'unit-test-access-token' };
+    const testCases = [
+      {
+        name: 'follows login procedure with auth0lock',
+        configuration: { enableLockWidget: true },
+        setExpectations(auth, authMock, tokenExpiryManagerMock, auth0LockFactoryMock, auth0Lock, auth0LockMock) {
+          authMock.expects('renewAuth').once().rejects('error');
+          authMock.expects('removeLogin').once();
+          authMock.expects('renewAuth').once().resolves(testLoginInfo);
+          authMock.expects('getDetailedProfile').withExactArgs(testLoginInfo.idToken, testLoginInfo.sub).once().resolves(testProfile);
+          authMock.expects('profileRefreshed').withExactArgs(testProfile).once().resolves();
+          auth0LockMock.expects('on').withExactArgs('authenticated', sinon.match.func)
+            .callsFake((event, cb) => cb(testAuthResult));
+          auth0LockMock.expects('on').withExactArgs('authorization_error', sinon.match.func).once();
+          auth0LockMock.expects('getUserInfo').withExactArgs(testAuthResult.accessToken, sinon.match.func)
+            .callsFake((accessToken, cb) => cb(null, testProfile));
+          auth0LockFactoryMock.expects('createAuth0Lock').once().returns(auth0Lock);
+        },
+      },
+      // add test when auth0 lock fails to login (once we handle that failure)
+      {
+        name: 'follows login procedure without auth0lock',
+        configuration: { enableLockWidget: false },
+        setExpectations(auth, authMock) {
+          authMock.expects('renewAuth').once().resolves(testLoginInfo);
+          authMock.expects('getDetailedProfile').withExactArgs(testLoginInfo.idToken, testLoginInfo.sub).once().resolves(testProfile);
+          authMock.expects('profileRefreshed').withExactArgs(testProfile).once().resolves();
+        },
+      },
+      {
+        name: 'does not call auth0lock if it is disabled and the sso auth failed',
+        configuration: { enableLockWidget: false },
+        setExpectations(auth, authMock) {
+          authMock.expects('renewAuth').once().rejects(catchableError);
+          authMock.expects('removeLogin').once();
+        },
+      },
+      {
+        name: 'returns immediately if valid token is available',
+        configuration: { enableLockWidget: false },
+        setExpectations(auth, authMock, tokenExpiryManagerMock) {
+          // eslint-disable-next-line no-param-reassign
+          auth.authResult = testAuthResult;
+          tokenExpiryManagerMock.expects('getRemainingMillisToTokenExpiry').once().returns(1000);
+          authMock.expects('renewAuth').never();
+        },
+      },
+      {
+        name: 'follows login procedure if valid token is available but forceTokenRefresh is set',
+        configuration: { enableLockWidget: false, forceTokenRefresh: true },
+        setExpectations(auth, authMock) {
+          // eslint-disable-next-line no-param-reassign
+          auth.authResult = testAuthResult;
+          authMock.expects('renewAuth').once().resolves(testLoginInfo);
+          authMock.expects('getDetailedProfile').withExactArgs(testLoginInfo.idToken, testLoginInfo.sub).once().resolves(testProfile);
+          authMock.expects('profileRefreshed').withExactArgs(testProfile).once().resolves();
+        },
+      },
+    ];
 
-      const promise = auth.ensureLoggedIn();
+    return testCases.map(testCase =>
+      it(testCase.name, () => {
+        const auth0Lock = { on() {}, show() {}, hide() {}, getUserInfo() {} };
+        const auth0LockMock = sandbox.mock(auth0Lock);
+        const auth0LockFactoryMock = sandbox.mock(Auth0LockFactory);
+        const tokenExpiryManager = { getRemainingMillisToTokenExpiry() {} };
+        const tokenExpiryManagerMock = sandbox.mock(tokenExpiryManager);
+        const auth = new Auth();
+        auth.tokenExpiryManager = tokenExpiryManager;
+        const authMock = sandbox.mock(auth);
 
-      return promise
-        .then(() => {
-          mock.verify();
-        });
-    });
+        testCase.setExpectations(auth, authMock, tokenExpiryManagerMock, auth0LockFactoryMock,
+          auth0Lock, auth0LockMock);
+
+        return auth.ensureLoggedIn(testCase.configuration)
+          .then(() => {
+            authMock.verify();
+            auth0LockFactoryMock.verify();
+            auth0LockMock.verify();
+            tokenExpiryManagerMock.verify();
+          })
+          .catch((e) => {
+            if (e.name !== catchableError) {
+              throw e;
+            }
+          });
+      }));
   });
 });

--- a/test/token-expiry-manager.test.js
+++ b/test/token-expiry-manager.test.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-unused-expressions */
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chai from 'chai';
+import windowInteraction from '../src/window-interaction';
+import TokenExpiryManager from '../src/token-expiry-manager';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+let sandbox;
+beforeEach(() => {
+  sandbox = sinon.sandbox.create();
+});
+afterEach(() => sandbox.restore());
+
+describe('token-expiry-manager.js', () => {
+  describe('getRemainingMillisToTokenExpiry()', () => {
+    it('returns 0 if there is no token expiry date stored', () => {
+      const tokenExpiryManager = new TokenExpiryManager();
+      expect(tokenExpiryManager.getRemainingMillisToTokenExpiry()).to.equal(0);
+    });
+
+    it('returns number of miliseconds remaining to token expiry', () => {
+      const expiresAt = 15000;
+      const dateNow = 10000;
+      const expectedRemainingMs = 5000;
+
+      const dateMock = sandbox.mock(Date);
+      dateMock.expects('now').returns(dateNow);
+      const tokenExpiryManager = new TokenExpiryManager();
+      tokenExpiryManager.tokenExpiresAt = expiresAt;
+
+      expect(tokenExpiryManager.getRemainingMillisToTokenExpiry()).to.equal(expectedRemainingMs);
+      dateMock.verify();
+    });
+  });
+
+  describe('scheduleTokenRefresh()', () => {
+    it('schedules token refresh at 2/3 of its lifetime', () => {
+      const expiresIn = 15000;
+      const dateNow = 10000;
+      const expectedExpiresAt = 20000;
+      const expectedRefreshDelay = 10000;
+      const expectedRefreshHandle = 'test-handle';
+      const expectedRefreshFunction = () => {};
+
+      const dateMock = sandbox.mock(Date);
+      dateMock.expects('now').returns(dateNow);
+      const windowInteractionMock = sandbox.mock(windowInteraction);
+      windowInteractionMock.expects('setTimeout')
+        .withExactArgs(expectedRefreshFunction, expectedRefreshDelay).returns(expectedRefreshHandle);
+
+      const tokenExpiryManager = new TokenExpiryManager();
+      tokenExpiryManager.scheduleTokenRefresh({ expiresIn: expiresIn / 1000 }, expectedRefreshFunction);
+
+      expect(tokenExpiryManager.tokenExpiresAt).to.equal(expectedExpiresAt);
+      expect(tokenExpiryManager.tokenRefreshHandle).to.equal(expectedRefreshHandle);
+      dateMock.verify();
+      windowInteractionMock.verify();
+    });
+
+    it('clears old and schedules new token refresh', () => {
+      const expiresIn = 15000;
+      const dateNow = 10000;
+      const oldRefreshHandle = 'old-handle';
+      const newRefreshHandle = 'new-handle';
+
+      const dateMock = sandbox.mock(Date);
+      dateMock.expects('now').returns(dateNow);
+      const windowInteractionMock = sandbox.mock(windowInteraction);
+      windowInteractionMock.expects('clearTimeout').withExactArgs(oldRefreshHandle);
+      windowInteractionMock.expects('setTimeout')
+        .withExactArgs(sinon.match.func, sinon.match.number).returns(newRefreshHandle);
+
+      const tokenExpiryManager = new TokenExpiryManager();
+      tokenExpiryManager.tokenRefreshHandle = oldRefreshHandle;
+      tokenExpiryManager.scheduleTokenRefresh({ expiresIn: expiresIn / 1000 }, () => {});
+
+      expect(tokenExpiryManager.tokenRefreshHandle).to.equal(newRefreshHandle);
+      dateMock.verify();
+      windowInteractionMock.verify();
+    });
+  });
+
+  describe('cancelTokenRefresh()', () => {
+    it('clears stored token expiry and cancels token refresh', () => {
+      const existingHandle = 'existing-handle';
+      const windowInteractionMock = sandbox.mock(windowInteraction);
+      windowInteractionMock.expects('clearTimeout').withExactArgs(existingHandle);
+
+      const tokenExpiryManager = new TokenExpiryManager();
+      tokenExpiryManager.tokenExpiresAt = 'token-expiry-time';
+      tokenExpiryManager.tokenRefreshHandle = existingHandle;
+
+      tokenExpiryManager.cancelTokenRefresh();
+      expect(tokenExpiryManager.tokenExpiresAt).to.be.null;
+      expect(tokenExpiryManager.tokenRefreshHandle).to.be.null;
+      windowInteractionMock.verify();
+    });
+  });
+});


### PR DESCRIPTION
Breaking changes:
- `stayLoggedIn()` method is no longer available (background refresh is enabled by default)
- `ensureLoggedIn({ enableLockWidget: bool, forceRefresh: bool })` can be called repeatedly. It will or will not (if there is already valid token) get a new token

Details:
- clients continue retrieving token via `tokenRefreshed` hook but there is also an option of `getLastAuthResult()` which can be used as a token provider. It does not guarantee token availability though
- token together with its expiry time is stored in memory
- scheduled refresh is automatically removed on logout or when login is removed programatically