### PR TITLE
Handle when window.origin is undefined

### DIFF
--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -209,6 +209,8 @@ export default class auth {
       usePostMessage: true,
       audience: this.config.audience,
       responseType: 'id_token token',
+      postMessageOrigin: window.location.origin ||
+          `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}`,
     };
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
See a related PR at https://github.com/auth0/auth0.js/pull/598. But we can also fix it here without that dependency.