### PR TITLE
Enforce single auth popup

### DIFF
--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -156,9 +156,9 @@ export default class auth {
     const authPromise = this.renewAuthSequencePromise
       .then(() => this.renewAuth())
       .catch((e) => {
-        this.removeLogin();
         // if auth0 lock is not enabled, error out
         if (!configuration.enableLockWidget) {
+          this.removeLogin();
           return Promise.reject(e);
         }
         this.log('Renew authorization did not succeed, falling back to login widget', e);
@@ -196,7 +196,11 @@ export default class auth {
         });
       })
       .then(loginInfo => this.getDetailedProfile(loginInfo.idToken, loginInfo.sub))
-      .then(profile => this.profileRefreshed(profile));
+      .then(profile => this.profileRefreshed(profile))
+      .catch((err) => {
+        this.removeLogin();
+        throw err;
+      });
 
     this.renewAuthSequencePromise = authPromise.catch(() => { /* ignore since renewAuthSequcne may never be a rejected promise to have successful continuations */ });
 

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -194,8 +194,16 @@ export default class auth {
           lock.show();
         });
       })
-      .then(loginInfo => this.getDetailedProfile(loginInfo.idToken, loginInfo.sub))
-      .then(profile => this.profileRefreshed(profile))
+      .then((loginInfo) => {
+        if (loginInfo.idToken && loginInfo.sub) {
+          return this.getDetailedProfile(loginInfo.idToken, loginInfo.sub)
+            .then(profile => this.profileRefreshed(profile))
+            .catch((err) => {
+              this.log('Failed to get detailed profile information', err);
+            });
+        }
+        return Promise.resolve();
+      })
       .catch((err) => {
         this.removeLogin();
         throw err;

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -171,7 +171,7 @@ export default class auth {
                 lock.getUserInfo(authResult.accessToken, (error, profile) => {
                   lock.hide();
                   if (error) {
-                    this.log(error);
+                    this.log('Error while retrieving user information after successful Auth0Lock authentication', error);
                     reject(error);
                   } else {
                     resolve({
@@ -180,6 +180,10 @@ export default class auth {
                     });
                   }
                 });
+              })
+              .catch((error) => {
+                this.log('Error while calling renewAuth after successful Auth0Lock authentication', error);
+                reject(error);
               });
           });
 

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -13,6 +13,7 @@ export default class auth {
     this.config = config || {};
     this.authResult = null;
     this.tokenExpiryManager = new TokenExpiryManager();
+    this.renewAuthSequencePromise = Promise.resolve();
   }
 
   /**
@@ -152,8 +153,8 @@ export default class auth {
       options = Object.assign(options, this.config.auth0LockOptions);
     }
 
-    // The 1000ms here is guarantee that the websocket is finished loading
-    return this.renewAuth()
+    return this.renewAuthSequencePromise
+      .then(() => this.renewAuth())
       .catch((e) => {
         this.removeLogin();
         // if auth0 lock is not enabled, error out

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -172,7 +172,7 @@ export default class auth {
                   lock.hide();
                   if (error) {
                     this.log('Error while retrieving user information after successful Auth0Lock authentication', error);
-                    reject(error);
+                    resolve({ idToken: authResult.idToken, sub: null });
                   } else {
                     resolve({
                       idToken: authResult.idToken,
@@ -183,7 +183,7 @@ export default class auth {
               })
               .catch((error) => {
                 this.log('Error while calling renewAuth after successful Auth0Lock authentication', error);
-                reject(error);
+                resolve({ idToken: authResult.idToken, sub: null });
               });
           });
 

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -158,7 +158,6 @@ export default class auth {
       .catch((e) => {
         // if auth0 lock is not enabled, error out
         if (!configuration.enableLockWidget) {
-          this.removeLogin();
           return Promise.reject(e);
         }
         this.log('Renew authorization did not succeed, falling back to login widget', e);

--- a/src/auth0-sso-login.js
+++ b/src/auth0-sso-login.js
@@ -153,7 +153,7 @@ export default class auth {
       options = Object.assign(options, this.config.auth0LockOptions);
     }
 
-    return this.renewAuthSequencePromise
+    const authPromise = this.renewAuthSequencePromise
       .then(() => this.renewAuth())
       .catch((e) => {
         this.removeLogin();
@@ -197,6 +197,10 @@ export default class auth {
       })
       .then(loginInfo => this.getDetailedProfile(loginInfo.idToken, loginInfo.sub))
       .then(profile => this.profileRefreshed(profile));
+
+    this.renewAuthSequencePromise = authPromise.catch(() => { /* ignore since renewAuthSequcne may never be a rejected promise to have successful continuations */ });
+
+    return authPromise;
   }
 
   /**

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -178,7 +178,6 @@ describe('auth0-sso-login.js', () => {
         configuration: { enableLockWidget: true },
         setExpectations(objects) {
           objects.authMock.expects('renewAuth').once().rejects('error');
-          objects.authMock.expects('removeLogin').once();
           objects.authMock.expects('renewAuth').once().resolves(testLoginInfo);
           objects.authMock.expects('getDetailedProfile').withExactArgs(testLoginInfo.idToken, testLoginInfo.sub)
             .resolves(testProfile);


### PR DESCRIPTION
The call to `renewAuth` is now sequenced so that we don't end up with multiple simultaneous calls, especially in the follow up to show the Auth0 popup.