### PR TITLE
Create ability to specify the connection to bypass the lock widget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ let auth = new Auth(config);
 let defaultConfiguration = {
   enabledHostedLogin: true,  // if Auth0's SSO fails, use the hosted login screen
   forceTokenRefresh: false // force refresh even if there is a valid token available
-  redirectUri: window.location.href // specify an override
+  redirectUri: window.location.href, // specify an override
+  explicitConnection: null // specify an explicit connection to use for this instance of calling ensureLoggedIn, will override the global configuration value
 };
 // Logs the user in and returns a promise, when succeeded, the user is logged in
 // and a valid JWT was provided (via tokenRefreshed hook).
@@ -88,6 +89,9 @@ let config = {
 
   // the logout URL, which should be accessible by a non-authenticated user, default is `window.location.href`
   logoutRedirectUri: `${window.location.origin}/#/logout`,
+
+  // specify an explicit connection to use, which allows bypassing the lock widget
+  explicitConnection: null,
 
   // hooks to get callback calls into the login/logout workflow
   hooks: {

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ let config = {
   // the logout URL, which should be accessible by a non-authenticated user, default is `window.location.href`
   logoutRedirectUri: `${window.location.origin}/#/logout`,
 
+  // the application root, by default the redirect from universal lock will redirect here before replacing history with the specified redirect.
+  applicationRoot: '/',
+
   // specify an explicit connection to use, which allows bypassing the lock widget
   explicitConnection: null,
 

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -14,7 +14,7 @@ chai.use(sinonChai);
 
 let sandbox;
 beforeEach(() => {
-  sandbox = sinon.sandbox.create();
+  sandbox = sinon.createSandbox();
 });
 afterEach(() => sandbox.restore());
 

--- a/test/auth0-sso-login.test.js
+++ b/test/auth0-sso-login.test.js
@@ -48,7 +48,9 @@ describe('auth0-sso-login.js', () => {
         const profile = { unitTestProfile: 'unit-test-log-message' };
         mock.expects('profileRefreshed').withExactArgs(profile).once().resolves();
         const auth = new Auth({ hooks: { profileRefreshed: hook.profileRefreshed } });
-        return auth.profileRefreshed(profile)
+        const mockAuthed = sandbox.mock(auth);
+        mockAuthed.expects('getProfile').resolves(profile);
+        return auth.refreshProfile(profile)
         .then(() => {
           mock.verify();
         });
@@ -59,7 +61,7 @@ describe('auth0-sso-login.js', () => {
         const auth = new Auth();
 
         // return promise, to ensure it didn't fail
-        return auth.profileRefreshed(profile);
+        return auth.refreshProfile(profile);
       });
     });
 
@@ -182,7 +184,7 @@ describe('auth0-sso-login.js', () => {
           objects.authMock.expects('getIdToken').once().resolves();
           objects.authMock.expects('renewAuth').once().rejects('error');
           objects.loggerMock.expects('log');
-          objects.authMock.expects('universalAuth').withExactArgs(redirectUri).once().resolves(testProfile);
+          objects.authMock.expects('universalAuth').withExactArgs(redirectUri, undefined).once().resolves(testProfile);
         }
       },
       {
@@ -190,7 +192,7 @@ describe('auth0-sso-login.js', () => {
         configuration: { enabledHostedLogin: true, redirectUri: redirectUri },
         setExpectations(objects) {
           objects.authMock.expects('renewAuth').once().rejects('error');
-          objects.authMock.expects('universalAuth').withExactArgs(redirectUri).once().rejects(catchableError);
+          objects.authMock.expects('universalAuth').withExactArgs(redirectUri, undefined).once().rejects(catchableError);
           objects.loggerMock.expects('log');
           objects.authMock.expects('removeLogin').withExactArgs().once();
         }

--- a/test/token-expiry-manager.test.js
+++ b/test/token-expiry-manager.test.js
@@ -11,7 +11,7 @@ chai.use(sinonChai);
 
 let sandbox;
 beforeEach(() => {
-  sandbox = sinon.sandbox.create();
+  sandbox = sinon.createSandbox();
 });
 afterEach(() => sandbox.restore());
 


### PR DESCRIPTION
* We were unnecessarily calling `getProfile` when we didn't have a hook defined
* Added the ability to specify a connection to universal auth to skip having a user unnecessarily clicking a single button when there is only one connection (no idea why auth0 doesn't do this by default.