### PR TITLE
Disable push to github while token does not have permissions.

### DIFF
--- a/make.js
+++ b/make.js
@@ -36,8 +36,9 @@ commander
 .action(() => {
   console.log('After build package %s (%s)', packageMetadata.name, version);
   console.log('');
-  ci.PublishGitTag();
-  ci.MergeDownstream('release/', 'master');
+  // Security for travis has been disabled, when it is reenabled we can turn this back on.
+  // ci.PublishGitTag();
+  // ci.MergeDownstream('release/', 'master');
 });
 
 commander.parse(process.argv);


### PR DESCRIPTION
I noticed all the pushes to master failing, the reason is that the service account that was being used to do these pushes is no longer active. If we want to keep this on, then we'll need to add a service to have permissions here. I don't know what you want the policy to be, but at least two other repos are also broken.

To unbreak this, I'm merging this MR, but someone should look into the other failing repos

https://travis-ci.org/Cimpress-MCP/auth0-sso-login.js/builds/626569354?utm_medium=notification&utm_source=github_status

![image](https://user-images.githubusercontent.com/5056218/71839979-ad6fed80-30bc-11ea-9687-c32598f295c8.png)
